### PR TITLE
Gulp-kit compilation support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Hardboiled Web Design Style Guide
+
+This is a fork, including a Gulpfile.js and Package.json file, in order to compile the index.kit file without CodeKit.
+
+## Requirements
+
+1. NodeJS and NPM must be installed.
+
+## Usage
+
+1. Open a terminal, and cd to the repository's folder.
+2. Run `npm install` to install gulp-kit, gulp and node-kit.
+3. Run `gulp compile` to compile the index.kit file into index.html.
+
+Any changes can be made in Gulpfile.js.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,8 @@
+var gulp = require('gulp')
+var kit = require('gulp-kit')
+
+gulp.task('compile', function(){
+    return gulp.src('index.kit')
+    .pipe(kit())
+    .pipe(gulp.dest('./'));
+});

--- a/ignore.txt
+++ b/ignore.txt
@@ -2,3 +2,4 @@
 *.psd
 *.esproj
 elements/*
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "hardboiled-style-guide",
+  "version": "1.0.0",
+  "description": "The style guide template for Hardboiled Web Design",
+  "main": "index.kit",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/malarkey/hardboiled-style-guide.git"
+  },
+  "keywords": [
+    "styleguide",
+    "hardboiled",
+    "web",
+    "design",
+    "node-kit"
+  ],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/malarkey/hardboiled-style-guide/issues"
+  },
+  "homepage": "https://github.com/malarkey/hardboiled-style-guide#readme",
+  "devDependencies": {
+    "gulp": "^3.9.0",
+    "gulp-kit": "^0.3.0",
+    "node-kit": "^0.9.0"
+  }
+}


### PR DESCRIPTION
I've added a Package.json and gulpfile.js in order to enable compiling of the .kit file, without relying upon CodeKit.  A quick test indicates everything is working fine.

I've also added instructions on using it to the README.md file.
