### PR TITLE
Small fix to on table of contents id links

### DIFF
--- a/config.codekit
+++ b/config.codekit
@@ -82,15 +82,6 @@
 		"outputPathIsOutsideProject": 0,
 		"outputPathIsSetByUser": 0
 		},
-	"\/partials\/_head.html": {
-		"fileType": 8192,
-		"ignore": 1,
-		"ignoreWasSetByUser": 0,
-		"inputAbbreviatedPath": "\/partials\/_head.html",
-		"outputAbbreviatedPath": "No Output Path",
-		"outputPathIsOutsideProject": 0,
-		"outputPathIsSetByUser": 0
-		},
 	"\/partials\/_module-pagination.html": {
 		"fileType": 8192,
 		"ignore": 1,
@@ -702,7 +693,7 @@
 	},
 "hooks": [
 	],
-"lastSavedByUser": "Andrew Clarke",
+"lastSavedByUser": "Scott Gruber",
 "manualImportLinks": {
 	},
 "projectAttributes": {

--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
 <meta name="msapplication-TileImage" content="/assets/img/site/apple-touch-icon-precomposed.png">
 
 <!-- Fonts -->
-<link href='https://fonts.googleapis.com/css?family=Merriweather|Lato:400,300,700' rel='stylesheet' type='text/css'></head>
+<link href='https://fonts.googleapis.com/css?family=Merriweather|Lato:400,300,700' rel='stylesheet' type='text/css'>
+</head>
 
 <body id="www-hardboiledwebdesign-com">
 
@@ -328,7 +329,7 @@
 
 <!-- Next _____________________________________________________________-->
 
-<section class="pattern__page" id="pattern__headings">
+<section class="pattern__page" id="pattern__typography__headings">
 
 <h1 class="pattern__heading">Headings</h1>
 
@@ -537,7 +538,7 @@
 
 <!-- Next _____________________________________________________________-->
 
-<section class="pattern__page" id="pattern__list__text">
+<section class="pattern__page" id="pattern__list__modules">
 
 <div class="pattern-col-all">
 <div class="pattern-col pattern-col2-col3">
@@ -559,6 +560,13 @@
 </dl>
 </div><!-- pattern-col -->
 </div><!-- col-all -->
+
+</section><!-- pattern__page -->
+
+
+<!-- Next _____________________________________________________________-->
+
+<section class="pattern__page" id="pattern__list__text">
 
 <div class="pattern-col-all">
 <div class="pattern-col pattern-col2-col3">
@@ -614,9 +622,7 @@
 <section class="pattern__page" id="pattern__modules__faqs">
 
 <div class="pattern-col-all">
-<div class="pattern-col pattern-col2-col3">
 <h1 class="pattern__page__header">FAQs</h1>
-</div><!-- pattern-col -->
 </div><!-- col-all -->
 
 <div class="pattern-col-all">
@@ -648,7 +654,7 @@
 
 <!-- Next _____________________________________________________________-->
 
-<section class="pattern__page" id="pattern__tables">
+<section class="pattern__page" id="pattern__list__tables">
 
 <div class="pattern-col-all">
 <h1 class="pattern__page__header">Tables</h1>

--- a/index.kit
+++ b/index.kit
@@ -291,7 +291,7 @@
 
 <!-- Next _____________________________________________________________-->
 
-<section class="pattern__page" id="pattern__headings">
+<section class="pattern__page" id="pattern__typography__headings">
 
 <h1 class="pattern__heading">Headings</h1>
 
@@ -500,7 +500,7 @@
 
 <!-- Next _____________________________________________________________-->
 
-<section class="pattern__page" id="pattern__list__text">
+<section class="pattern__page" id="pattern__list__modules">
 
 <div class="pattern-col-all">
 <div class="pattern-col pattern-col2-col3">
@@ -522,6 +522,13 @@
 </dl>
 </div><!-- pattern-col -->
 </div><!-- col-all -->
+
+</section><!-- pattern__page -->
+
+
+<!-- Next _____________________________________________________________-->
+
+<section class="pattern__page" id="pattern__list__text">
 
 <div class="pattern-col-all">
 <div class="pattern-col pattern-col2-col3">
@@ -577,9 +584,7 @@
 <section class="pattern__page" id="pattern__modules__faqs">
 
 <div class="pattern-col-all">
-<div class="pattern-col pattern-col2-col3">
 <h1 class="pattern__page__header">FAQs</h1>
-</div><!-- pattern-col -->
 </div><!-- col-all -->
 
 <div class="pattern-col-all">
@@ -611,7 +616,7 @@
 
 <!-- Next _____________________________________________________________-->
 
-<section class="pattern__page" id="pattern__tables">
+<section class="pattern__page" id="pattern__list__tables">
 
 <div class="pattern-col-all">
 <h1 class="pattern__page__header">Tables</h1>


### PR DESCRIPTION
Noticed what I think were a couple of missing anchor links in Contents to jump to sections for list modules, text level elements, tables on page.
